### PR TITLE
Removing duplicate config key

### DIFF
--- a/lib/mamiya/agent/tasks/switch.rb
+++ b/lib/mamiya/agent/tasks/switch.rb
@@ -125,7 +125,6 @@ module Mamiya
             target: release_path,
             config: config,
             logger: logger,
-            config: config,
             labels: agent.labels,
             no_release: !!task['no_release'],
             do_release: !!task['do_release'],


### PR DESCRIPTION
Duplicate config key was causing a warning