### PR TITLE
ensuring we pass build_from path as string instead of class Pathname

### DIFF
--- a/lib/mamiya/helpers/git.rb
+++ b/lib/mamiya/helpers/git.rb
@@ -45,7 +45,7 @@ prepare_build do |update|
   if !update && !self.repository
     logger.warn 'Skipping cloning repository because script.repository not set'
   elsif !update
-    run "git", "clone", self.repository, self.build_from
+    run "git", "clone", self.repository, self.build_from.to_s
   end
 
   Dir.chdir(self.build_from) do


### PR DESCRIPTION
On the first package build (git not cloned yet), `self.build_from` is passed as class `Pathname` instead of `String` which causes the build to fail.