### PR TITLE
Support environment variables with run

### DIFF
--- a/lib/mamiya/script.rb
+++ b/lib/mamiya/script.rb
@@ -60,12 +60,14 @@ module Mamiya
         run_id = generate_run_id()
         logger = self.logger["run:#{run_id}"]
 
+        env = args.last.is_a?(Hash) ? args.pop : {}
+
         logger.info("$ #{args.shelljoin}")
 
         err_r, err_w = IO.pipe
         out_r, out_w = IO.pipe
 
-        pid = spawn(*args.map(&:to_s), out: out_w, err: err_w)
+        pid = spawn(env, *args.map(&:to_s), out: out_w, err: err_w)
 
         [out_w, err_w].each(&:close)
 

--- a/lib/mamiya/script.rb
+++ b/lib/mamiya/script.rb
@@ -61,8 +61,9 @@ module Mamiya
         logger = self.logger["run:#{run_id}"]
 
         env = args.last.is_a?(Hash) ? args.pop : {}
+        shellenv = env.any? ? escape_env(env) + " " : ""
 
-        logger.info("$ #{args.shelljoin}")
+        logger.info("$ #{shellenv}#{args.shelljoin}")
 
         err_r, err_w = IO.pipe
         out_r, out_w = IO.pipe
@@ -178,6 +179,12 @@ module Mamiya
         @last_run_id_time = t
         id
       end
+    end
+
+    def escape_env(hash)
+      hash.map { |key, value|
+        [key.to_s.shellescape, value.to_s.shellescape].join("=")
+      }.join(" ")
     end
   end
 end

--- a/spec/script_spec.rb
+++ b/spec/script_spec.rb
@@ -37,9 +37,16 @@ describe Mamiya::Script do
         .from(false).to(true)
     end
 
-    it "runs command with environment variables" do
-      output =  script.run("env", { "foo" => "bar" })
-      expect(output).to include("foo=bar")
+    context "when given environment variables" do
+      it "runs command with environment variables" do
+        output =  script.run("env", { "foo" => "bar" })
+        expect(output).to include("foo=bar")
+      end
+
+      it "logs environment variables with command" do
+        script.run("env", { "foo" => "bar" })
+        expect(log).to include([:info, "$ foo=bar env"])
+      end
     end
 
     context "when the command failed" do

--- a/spec/script_spec.rb
+++ b/spec/script_spec.rb
@@ -37,6 +37,11 @@ describe Mamiya::Script do
         .from(false).to(true)
     end
 
+    it "runs command with environment variables" do
+      output =  script.run("env", { "foo" => "bar" })
+      expect(output).to include("foo=bar")
+    end
+
     context "when the command failed" do
       it "logs error" do
         begin


### PR DESCRIPTION
When a hash is given at the last argument, it is used as environment
variables like:

    run "rake", "assets:precompile", { "RAILS_ENV" => "production" }

It is executed and logged as:

    $ RAILS_ENV=production rake assets:precompile