### PR TITLE
Force rename(2)

### DIFF
--- a/lib/mamiya/steps/switch.rb
+++ b/lib/mamiya/steps/switch.rb
@@ -37,7 +37,7 @@ module Mamiya
 
         next_path = script.release_path.parent.join(script.current_path.basename)
         next_path.make_symlink(target.realpath)
-        FileUtils.mv(next_path, script.current_path)
+        File.rename(next_path, script.current_path)
       end
 
       def release

--- a/spec/steps/switch_spec.rb
+++ b/spec/steps/switch_spec.rb
@@ -157,8 +157,10 @@ describe Mamiya::Steps::Switch do
     end
 
     context "when current already exists" do
+      let(:previous_release_path) { releases_dir.join('20140515000707').tap(&:mkdir) }
+
       before do
-          current_path.make_symlink('releases/20140515000707')
+        current_path.make_symlink(previous_release_path)
       end
 
       it "links current to release_path" do


### PR DESCRIPTION
`FileUtils.mv('foo', 'bar')` moves bar to foo/bar when foo is a
directory. Since there's no option corresponding to `mv -T`, use
`File.rename` instead of `FileUtils.mv` . It could fail with
Errno::EXDEV, but I believe it doesn't happen in practice...