### PR TITLE
Run Dir.chdir with global lock

### DIFF
--- a/lib/mamiya.rb
+++ b/lib/mamiya.rb
@@ -3,9 +3,9 @@ require 'thread'
 
 module Mamiya
 
-  @chdir_mutex = Thread::Mutex.new
+  @chdir_monitor = Monitor.new
   def self.chdir(dir, &block)
-    @chdir_mutex.synchronize do
+    @chdir_monitor.synchronize do
       Dir.chdir(dir, &block)
     end
   end

--- a/lib/mamiya.rb
+++ b/lib/mamiya.rb
@@ -1,5 +1,12 @@
 require "mamiya/version"
+require 'thread'
 
 module Mamiya
-  # Your code goes here...
+
+  @chdir_mutex = Thread::Mutex.new
+  def self.chdir(dir, &block)
+    @chdir_mutex.synchronize do
+      Dir.chdir(dir, &block)
+    end
+  end
 end

--- a/lib/mamiya/helpers/git.rb
+++ b/lib/mamiya/helpers/git.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'mamiya'
 
 set_default :git_remote, 'origin'
 set_default :commit, "#{self.git_remote}/HEAD"
@@ -48,7 +49,7 @@ prepare_build do |update|
     run "git", "clone", self.repository, self.build_from
   end
 
-  Dir.chdir(self.build_from) do
+  Mamiya.chdir(self.build_from) do
     logger.info Dir.pwd
     run "git", "fetch", self.git_remote
     run "git", "remote", "prune", self.git_remote, allow_failure: true
@@ -81,7 +82,7 @@ end
 options[:manage_script] = true unless options.key?(:manage_script)
 options[:script_auto_additionals] = true unless options.key?(:script_auto_additionals)
 if options[:manage_script] && _file
-  Dir.chdir(File.dirname(_file)) do
+  Mamiya.chdir(File.dirname(_file)) do
     break unless git_managed?
 
     script_git_head = git_head()

--- a/lib/mamiya/package.rb
+++ b/lib/mamiya/package.rb
@@ -1,3 +1,4 @@
+require 'mamiya'
 require 'mamiya/logger'
 
 require 'pathname'
@@ -76,7 +77,7 @@ module Mamiya
       meta['name'] = self.name
       File.write meta_in_build, self.meta.to_json
 
-      Dir.chdir(build_dir) do
+      Mamiya.chdir(build_dir) do
         excludes = exclude_from_package.flat_map { |exclude| ['--exclude', exclude] }
         dereference = dereference_symlinks ? ['-h'] : []
 

--- a/lib/mamiya/script.rb
+++ b/lib/mamiya/script.rb
@@ -135,6 +135,7 @@ module Mamiya
 
     def cd(*args)
       logger.info "$ cd #{args[0]}"
+      # FIXME: This could make conflict with other threads
       Dir.chdir *args
     end
 

--- a/lib/mamiya/steps/build.rb
+++ b/lib/mamiya/steps/build.rb
@@ -1,3 +1,4 @@
+require 'mamiya'
 require 'mamiya/steps/abstract'
 require 'mamiya/package'
 
@@ -72,15 +73,12 @@ module Mamiya
       end
 
       def run_build
-        old_pwd = Dir.pwd
-        begin
-          # Using without block because chdir in block shows warning
-          Dir.chdir(script.build_from)
+        # FIXME: This could show warning saying "conflicting chdir during another chdir block".
+        # Do not use `Dir.chdir` without block anyware.
+        Mamiya.chdir(script.build_from) do
           logger.info "Running script.build"
           logger.debug "pwd=#{Dir.pwd}"
           script.build[]
-        ensure
-          Dir.chdir old_pwd
         end
       end
 
@@ -112,7 +110,7 @@ module Mamiya
       def set_metadata
         package.meta[:application] = script.application
         package.meta[:script] = File.basename(script_file)
-        Dir.chdir(script.build_from) do
+        Mamiya.chdir(script.build_from) do
           package.meta.replace script.package_meta[package.meta]
         end
       end
@@ -130,7 +128,7 @@ module Mamiya
       def package_name
         @package_name ||= begin
           logger.debug "Determining package name..."
-          name = Dir.chdir(script.build_from) {
+          name = Mamiya.chdir(script.build_from) {
             script.package_name[
               [Time.now.strftime("%Y%m%d%H%M%S"), script.application]
             ].join('-')

--- a/lib/mamiya/steps/prepare.rb
+++ b/lib/mamiya/steps/prepare.rb
@@ -1,3 +1,4 @@
+require 'mamiya'
 require 'mamiya/steps/abstract'
 
 require 'pathname'
@@ -8,20 +9,18 @@ module Mamiya
     class Prepare < Abstract
       def run!
         @exception = nil
-        old_pwd = Dir.pwd
-        Dir.chdir(target)
+        Mamiya.chdir(target) do
+          logger.info "Preparing #{target}..."
 
-        logger.info "Preparing #{target}..."
+          script.before_prepare(labels)[]
+          script.prepare(labels)[]
 
-        script.before_prepare(labels)[]
-        script.prepare(labels)[]
-
-        File.write target.join('.mamiya.prepared'), "#{Time.now.to_i}\n"
+          File.write target.join('.mamiya.prepared'), "#{Time.now.to_i}\n"
+        end
       rescue Exception => e
         @exception = e
         raise e
       ensure
-        Dir.chdir old_pwd if old_pwd
         logger.warn "Exception occured, cleaning up..." if @exception
 
         script.after_prepare(labels)[@exception]

--- a/lib/mamiya/steps/switch.rb
+++ b/lib/mamiya/steps/switch.rb
@@ -1,3 +1,4 @@
+require 'mamiya'
 require 'mamiya/steps/abstract'
 
 module Mamiya
@@ -44,14 +45,11 @@ module Mamiya
         # TODO: link with relative if available?
         # TODO: Restore this if FAILED
 
-        old_pwd = Dir.pwd
-        Dir.chdir(target)
+        Mamiya.chdir(target) do
+          logger.info "Releasing..."
 
-        logger.info "Releasing..."
-
-        script.release(labels)[@exception]
-      ensure
-        Dir.chdir old_pwd if old_pwd
+          script.release(labels)[@exception]
+        end
       end
 
       # XXX: dupe with prepare step. modulize?


### PR DESCRIPTION
Dir.chdir changes the process attribute, but mamiya uses Dir.chdir in
many threads, resulting in chdir conflict.