### PR TITLE
Fetch package tarball and metadata JSON atomically

### DIFF
--- a/lib/mamiya/storages/s3.rb
+++ b/lib/mamiya/storages/s3.rb
@@ -1,6 +1,7 @@
 require 'mamiya/package'
 require 'mamiya/storages/abstract'
 require 'aws-sdk-core'
+require 'fileutils'
 require 'json'
 
 module Mamiya
@@ -64,12 +65,16 @@ module Mamiya
           raise AlreadyFetched
         end
 
-        open(package_path, 'wb+') do |io|
+        tmp_package_path = "#{package_path}.fetching"
+        tmp_meta_path = "#{meta_path}.fetching"
+        open(tmp_package_path, 'wb+') do |io|
           s3.get_object({bucket: @config[:bucket], key: package_key}, target: io)
         end
-        open(meta_path, 'wb+') do |io|
+        open(tmp_meta_path, 'wb+') do |io|
           s3.get_object({bucket: @config[:bucket], key: meta_key}, target: io)
         end
+        FileUtils.mv(tmp_package_path, package_path)
+        FileUtils.mv(tmp_meta_path, meta_path)
 
         return Mamiya::Package.new(package_path)
 

--- a/lib/mamiya/storages/s3.rb
+++ b/lib/mamiya/storages/s3.rb
@@ -65,8 +65,8 @@ module Mamiya
           raise AlreadyFetched
         end
 
-        tmp_package_path = "#{package_path}.fetching"
-        tmp_meta_path = "#{meta_path}.fetching"
+        tmp_package_path = "#{package_path}.progress"
+        tmp_meta_path = "#{meta_path}.progress"
         open(tmp_package_path, 'wb+') do |io|
           s3.get_object({bucket: @config[:bucket], key: package_key}, target: io)
         end

--- a/lib/mamiya/storages/s3_proxy.rb
+++ b/lib/mamiya/storages/s3_proxy.rb
@@ -23,8 +23,8 @@ module Mamiya
           raise AlreadyFetched
         end
 
-        tmp_package_path = "#{package_path}.fetching"
-        tmp_meta_path = "#{meta_path}.fetching"
+        tmp_package_path = "#{package_path}.progress"
+        tmp_meta_path = "#{meta_path}.progress"
         open(tmp_package_path, 'wb+') do |io|
           proxy_get(package_key, io)
         end

--- a/lib/mamiya/storages/s3_proxy.rb
+++ b/lib/mamiya/storages/s3_proxy.rb
@@ -1,5 +1,6 @@
 require 'mamiya/package'
 require 'mamiya/storages/s3'
+require 'fileutils'
 
 module Mamiya
   module Storages
@@ -22,12 +23,16 @@ module Mamiya
           raise AlreadyFetched
         end
 
-        open(package_path, 'wb+') do |io|
+        tmp_package_path = "#{package_path}.fetching"
+        tmp_meta_path = "#{meta_path}.fetching"
+        open(tmp_package_path, 'wb+') do |io|
           proxy_get(package_key, io)
         end
-        open(meta_path, 'wb+') do |io|
+        open(tmp_meta_path, 'wb+') do |io|
           proxy_get(meta_key, io)
         end
+        FileUtils.mv(tmp_package_path, package_path)
+        FileUtils.mv(tmp_meta_path, meta_path)
 
         return Mamiya::Package.new(package_path)
 

--- a/spec/storages/s3_spec.rb
+++ b/spec/storages/s3_spec.rb
@@ -124,18 +124,18 @@ describe Mamiya::Storages::S3 do
       expect(options[:bucket]).to eq 'testbucket'
       expect(options[:key]).to eq "myapp/test.tar.gz"
       expect(send_options[:target]).to be_a_kind_of(File)
-      expect(send_options[:target].path).to eq tarball
+      expect(send_options[:target].path).to eq("#{tarball}.fetching")
 
       options, send_options = requests.shift
       expect(options[:bucket]).to eq 'testbucket'
       expect(options[:key]).to eq "myapp/test.json"
       expect(send_options[:target]).to be_a_kind_of(File)
-      expect(send_options[:target].path).to eq metafile
+      expect(send_options[:target].path).to eq("#{metafile}.fetching")
     end
 
     it "returns Mamiya::Package" do
       allow(s3).to receive(:get_object) do
-        File.write metafile, "{}\n"
+        File.write "#{metafile}.fetching", "{}\n"
       end
 
       expect(fetch).to be_a_kind_of(Mamiya::Package)
@@ -184,7 +184,7 @@ describe Mamiya::Storages::S3 do
           hash_including(bucket: 'testbucket', key: 'myapp/test.tar.gz'), hash_including(target: an_instance_of(File)))
         expect(s3).to receive(:get_object).with(
           hash_including(bucket: 'testbucket', key: 'myapp/test.json'), hash_including(target: an_instance_of(File))) do
-          File.write metafile, "{}\n"
+          File.write "#{metafile}.fetching", "{}\n"
         end
 
         fetch
@@ -199,7 +199,7 @@ describe Mamiya::Storages::S3 do
           hash_including(bucket: 'testbucket', key: 'myapp/test.tar.gz'), hash_including(target: an_instance_of(File)))
         expect(s3).to receive(:get_object).with(
           hash_including(bucket: 'testbucket', key: 'myapp/test.json'), hash_including(target: an_instance_of(File))) do
-          File.write metafile, "{}\n"
+          File.write "#{metafile}.fetching", "{}\n"
         end
 
         fetch

--- a/spec/storages/s3_spec.rb
+++ b/spec/storages/s3_spec.rb
@@ -124,18 +124,18 @@ describe Mamiya::Storages::S3 do
       expect(options[:bucket]).to eq 'testbucket'
       expect(options[:key]).to eq "myapp/test.tar.gz"
       expect(send_options[:target]).to be_a_kind_of(File)
-      expect(send_options[:target].path).to eq("#{tarball}.fetching")
+      expect(send_options[:target].path).to eq("#{tarball}.progress")
 
       options, send_options = requests.shift
       expect(options[:bucket]).to eq 'testbucket'
       expect(options[:key]).to eq "myapp/test.json"
       expect(send_options[:target]).to be_a_kind_of(File)
-      expect(send_options[:target].path).to eq("#{metafile}.fetching")
+      expect(send_options[:target].path).to eq("#{metafile}.progress")
     end
 
     it "returns Mamiya::Package" do
       allow(s3).to receive(:get_object) do
-        File.write "#{metafile}.fetching", "{}\n"
+        File.write "#{metafile}.progress", "{}\n"
       end
 
       expect(fetch).to be_a_kind_of(Mamiya::Package)
@@ -184,7 +184,7 @@ describe Mamiya::Storages::S3 do
           hash_including(bucket: 'testbucket', key: 'myapp/test.tar.gz'), hash_including(target: an_instance_of(File)))
         expect(s3).to receive(:get_object).with(
           hash_including(bucket: 'testbucket', key: 'myapp/test.json'), hash_including(target: an_instance_of(File))) do
-          File.write "#{metafile}.fetching", "{}\n"
+          File.write "#{metafile}.progress", "{}\n"
         end
 
         fetch
@@ -199,7 +199,7 @@ describe Mamiya::Storages::S3 do
           hash_including(bucket: 'testbucket', key: 'myapp/test.tar.gz'), hash_including(target: an_instance_of(File)))
         expect(s3).to receive(:get_object).with(
           hash_including(bucket: 'testbucket', key: 'myapp/test.json'), hash_including(target: an_instance_of(File))) do
-          File.write "#{metafile}.fetching", "{}\n"
+          File.write "#{metafile}.progress", "{}\n"
         end
 
         fetch


### PR DESCRIPTION
Prepare step checks the tarball existence to see if the fetch step has
been finished or not, but the tarball wasn't created atomically. So save
the intermediate file to the temporary path and rename(2) it to the
target path after the total write finished.