### PR TITLE
Remove bad package after rollback

### DIFF
--- a/lib/mamiya/agent.rb
+++ b/lib/mamiya/agent.rb
@@ -15,6 +15,7 @@ require 'mamiya/agent/tasks/fetch'
 require 'mamiya/agent/tasks/prepare'
 require 'mamiya/agent/tasks/clean'
 require 'mamiya/agent/tasks/switch'
+require 'mamiya/agent/tasks/remove'
 require 'mamiya/agent/tasks/ping'
 
 require 'mamiya/agent/handlers/task'
@@ -45,6 +46,7 @@ module Mamiya
         Mamiya::Agent::Tasks::Prepare,
         Mamiya::Agent::Tasks::Clean,
         Mamiya::Agent::Tasks::Switch,
+        Mamiya::Agent::Tasks::Remove,
         Mamiya::Agent::Tasks::Ping,
       ])
     end

--- a/lib/mamiya/agent/actions.rb
+++ b/lib/mamiya/agent/actions.rb
@@ -22,6 +22,10 @@ module Mamiya
         order_task('switch', app: application, pkg: package, labels: labels, no_release: no_release, do_release: do_release)
       end
 
+      def remove(application, package, labels: nil)
+        order_task('remove', app: application, pkg: package, labels: labels)
+      end
+
       def ping
         order_task('ping')
       end

--- a/lib/mamiya/agent/tasks/remove.rb
+++ b/lib/mamiya/agent/tasks/remove.rb
@@ -1,0 +1,28 @@
+require 'mamiya/agent/tasks/abstract'
+
+module Mamiya
+  class Agent
+    module Tasks
+      class Remove < Abstract
+        def run
+          release_path = config.deploy_to_for(application).join('releases', package)
+          logger.info "Removing package #{package} from releases (app=#{application})"
+          begin
+            release_path.rmtree
+          rescue Errno::ENOENT
+          end
+        end
+
+        private
+
+        def application
+          task['app']
+        end
+
+        def package
+          task['pkg']
+        end
+      end
+    end
+  end
+end

--- a/lib/mamiya/master/web.rb
+++ b/lib/mamiya/master/web.rb
@@ -118,6 +118,11 @@ module Mamiya
         end
       end
 
+      post '/packages/:application/:package/remove' do
+        status 204
+        master.remove(params[:application], params[:package], labels: params['labels'])
+      end
+
       get '/packages/:application/:package/status' do
         content_type :json
         meta = storage(params[:application]).meta(params[:package])

--- a/spec/agent/tasks/remove_spec.rb
+++ b/spec/agent/tasks/remove_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+require 'mamiya/agent/tasks/remove'
+require 'mamiya/configuration'
+
+RSpec.describe Mamiya::Agent::Tasks::Remove do
+  around do |example|
+    Dir.mktmpdir("mamiya-agent-tasks-remove-spec") do |tmpdir|
+      @tmpdir = Pathname.new(tmpdir)
+      example.run
+    end
+  end
+
+  let(:package_name) { 'mypkg' }
+  let(:task_queue) { double('task_queue', enqueue: nil) }
+  let(:agent) { double('agent', config: config) }
+  let(:deploy_to) { @tmpdir.join('targets') }
+  let(:release_path) { deploy_to.join('releases', package_name) }
+  let(:config) do 
+    Mamiya::Configuration.new.tap do |c|
+      c.applications[:myapp] = {deploy_to: deploy_to}
+    end
+  end
+  let(:job) { {'app' => 'myapp', 'pkg' => package_name} }
+
+  let(:task) { described_class.new(task_queue, job, agent: agent, raise_error: true) }
+
+  before do
+  end
+
+  describe "#execute" do
+    context "with specified package" do
+      it "removes specified package" do
+        release_path.mkpath
+
+        task.execute
+        expect(release_path).to_not be_exist
+      end
+    end
+
+    context "without specified package" do
+      it "does nothing" do
+        expect(release_path).to_not be_exist
+
+        task.execute
+        expect(release_path).to_not be_exist
+      end
+    end
+  end
+end

--- a/spec/master/web_spec.rb
+++ b/spec/master/web_spec.rb
@@ -258,6 +258,28 @@ describe Mamiya::Master::Web do
     end
   end
 
+  describe "POST /packages/:application/:package/remove" do
+    it "dispatches remove request" do
+      expect(master).to receive(:remove).with('myapp', 'mypackage', labels: nil)
+
+      post '/packages/myapp/mypackage/remove'
+
+      expect(last_response.status).to eq 204
+    end
+
+    context "with labels" do
+      it "dispatchs remove request with labels" do
+        expect(master).to receive(:remove).with('myapp', 'mypackage', labels: ['foo'])
+
+        post '/packages/myapp/mypackage/remove',
+          {'labels' =>  ["foo"]}.to_json,
+          'CONTENT_TYPE' => 'application/json'
+
+        expect(last_response.status).to eq 204
+      end
+    end
+  end
+
   describe "GET /package/:application/:package/status" do
     subject(:status) do
       res = get('/packages/myapp/mypackage/status')


### PR DESCRIPTION
It prevents rolled-back package from being re-deployed.
Suppose you have deployed and rolled back packages in the following
sequence.

1. Deploy package X
2. Deploy package Y
3. Rollback package, now X is running
4. Deploy package Z
5. Rollback package

At the last step, package Y is deployed because Y is the common previous
release of Z.
My solution is to remove package Y from releases at the step 3.