### PR TITLE
Use aws-sdk gem

### DIFF
--- a/lib/mamiya/storages/s3.rb
+++ b/lib/mamiya/storages/s3.rb
@@ -1,6 +1,6 @@
 require 'mamiya/package'
 require 'mamiya/storages/abstract'
-require 'aws-sdk-core'
+require 'aws-sdk'
 require 'fileutils'
 require 'json'
 

--- a/mamiya.gemspec
+++ b/mamiya.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor", ">= 0.18.1"
-  spec.add_runtime_dependency "aws-sdk-core", ">= 2.0.0"
+  spec.add_runtime_dependency "aws-sdk", ">= 2.0.0"
   spec.add_runtime_dependency "term-ansicolor", ">= 1.3.0"
   unless ENV["MAMIYA_VILLEIN_PATH"]
     spec.add_runtime_dependency "villein", ">= 0.5.0"

--- a/spec/storages/s3_proxy_spec.rb
+++ b/spec/storages/s3_proxy_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'aws-sdk-core'
 require 'mamiya/package'
 require 'mamiya/storages/abstract'
 require 'mamiya/storages/s3_proxy'

--- a/spec/storages/s3_spec.rb
+++ b/spec/storages/s3_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'aws-sdk-core'
 require 'mamiya/package'
 require 'mamiya/storages/abstract'
 require 'mamiya/storages/s3'


### PR DESCRIPTION
The aws-sdk-core gem became not to include aws-sdk-*, such as aws-sdk-s3 and aws-sdk-ec2 ([HEAD of master as of now failed](https://travis-ci.org/aycabta/mamiya/builds/281415202)), and so the role of compositive AWS gems is aws-sdk as it's now. This Pull Request fixes it.