### PR TITLE
fix 'no implicit conversion' error

### DIFF
--- a/lib/mamiya/master.rb
+++ b/lib/mamiya/master.rb
@@ -90,7 +90,7 @@ module Mamiya
           app: self.web,
           Port: options[:port] ? options[:port].to_i : 7761,
           Host: options[:bind] || '0.0.0.0', # TODO: IPv6
-          environment: options[:environment] || :development,
+          environment: options[:environment] || 'development',
           server: options[:server],
           Logger: logger['web']
         }


### PR DESCRIPTION
When using puma, this value passed to `ENV['RACK_ENV']` and it allows only string.