### PR TITLE
Fix exclude_git_clean_targets not excluding directories

### DIFF
--- a/lib/mamiya/helpers/git.rb
+++ b/lib/mamiya/helpers/git.rb
@@ -17,7 +17,7 @@ def git_ignored_files
     raise "`git clean -ndx` doesn't return line starting with 'Would remove' or 'Would skip'"
   end
 
-  excludes = git_clean_out.grep(prefix).map{ |_| _.sub(prefix, '').chomp }
+  excludes = git_clean_out.grep(prefix).map{ |_| _.sub(prefix, '').chomp.chomp('/') }
   if package_under
     excludes.grep(/^#{Regexp.escape(package_under)}/).map{ |_| _.sub(/^#{Regexp.escape(package_under)}\/?/, '') }
   else


### PR DESCRIPTION
`git clean -ndx` prints directories with trailing slash. But `--exclude` option of tar doesn't exclude if the path has trailing slash.

```
$ git init
Initialized empty Git repository in /tmp/test/.git/
$ mkdir untracked-directory
$ git clean -ndx
Would remove untracked-directory/

$ # with trailing slash
$ tar czf /tmp/test.tar.gz --exclude .git --exclude untracked-directory/ .
$ tar tf /tmp/test.tar.gz
./
./untracked-directory/

$ # without trailing slash
$ tar czf /tmp/test.tar.gz --exclude .git --exclude untracked-directory .
$ tar tf /tmp/test.tar.gz
./
```